### PR TITLE
Refactored exception handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
-				<!-- configuration> <source>1.6</source> <target>1.6</target> </configuration -->
+			    <configuration>
+				    <source>1.6</source>
+				    <target>1.6</target>
+			    </configuration>
 			</plugin>
 
                         <plugin>

--- a/service/src/main/java/org/pig/oink/commons/PigUtils.java
+++ b/service/src/main/java/org/pig/oink/commons/PigUtils.java
@@ -36,7 +36,7 @@ public class PigUtils {
 	private static final Logger logger= Logger.getLogger(PigUtils.class);
 
 	
-	public static void writeStatsFile (Path filePath, PigRequestStats stats) throws Exception {
+	public static void writeStatsFile (Path filePath, PigRequestStats stats) throws IOException {
 		Gson gson= new GsonBuilder().setPrettyPrinting().setDateFormat("yyyy/MM/dd-HH:mm").create();
 
 		String encodedStats= new String(Base64.encodeBase64URLSafeString(gson.toJson(stats, PigRequestStats.class).getBytes()));

--- a/service/src/main/java/org/pig/oink/operation/PigJobServer.java
+++ b/service/src/main/java/org/pig/oink/operation/PigJobServer.java
@@ -31,8 +31,7 @@ public interface PigJobServer {
 	 * @throws IllegalArgumentException - if script is not registered or any other error in input parameter
 	 * @throws IOException - if any error occurred while executing it
 	 */
-	public void submitPigJob(String requestId, String scriptName, PigRequestParameters params) throws 
-		IllegalArgumentException, IOException;
+	public void submitPigJob(String requestId, String scriptName, PigRequestParameters params) throws IOException;
 
 	/**
 	 * This method registers(writes) a file to HDFS
@@ -58,33 +57,30 @@ public interface PigJobServer {
 	 * @throws IOException 
 	 * @throws Exception 
 	 */
-	public PigRequestParameters getInputRequest(String requestId) throws IOException, Exception;
+	public PigRequestParameters getInputRequest(String requestId) throws IOException;
 
 	/**
 	 * This method returns the request execution statistics for a given requestId
 	 * @param requestId - ID that was generated when the request was submitted
 	 * @return PigRequestStats object
 	 * @throws IOException 
-	 * @throws Exception 
 	 */
-	public PigRequestStats getRequestStats(String requestId) throws IOException, Exception;
+	public PigRequestStats getRequestStats(String requestId) throws IOException;
 
 	/**
 	 * This method returns the status of the submitted request. This can be used for polling
 	 * @param requestId - ID that was generated when the request was submitted
 	 * @return String object
-	 * @throws IOException 
-	 * @throws Exception 
+	 * @throws IOException
 	 */
-	public String getRequestStatus(String requestId) throws IOException, Exception;
+	public String getRequestStatus(String requestId) throws IOException;
 	
 	/**
 	 * This method cancels the MapReduce jobs associated with the requestId
 	 * @param requestId - ID that was generated when the request was submitted
 	 * @return boolean object
-	 * @throws IOException 
-	 * @throws Exception 
+	 * @throws IOException
 	 */
-	public boolean cancelRequest(String requestId) throws IOException, Exception;
+	public boolean cancelRequest(String requestId) throws IOException;
 }
 	

--- a/service/src/main/java/org/pig/oink/operation/impl/PigJobServerImpl.java
+++ b/service/src/main/java/org/pig/oink/operation/impl/PigJobServerImpl.java
@@ -23,7 +23,6 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -44,7 +43,6 @@ import org.pig.oink.commons.Constants;
 import org.pig.oink.commons.PigUtils;
 import org.pig.oink.commons.Status;
 import org.pig.oink.operation.PigJobServer;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -115,11 +113,11 @@ public class PigJobServerImpl implements PigJobServer {
 	 */
 	@Override
 	public void registerFile(String filePath, InputStream fileInputStream) throws FileNotFoundException, IOException {
-		FileSystem fs = getFileSystem();
-		Path pathName= new Path(filePath);
+        FileSystem fs = getFileSystem();
+        Path pathName= new Path(filePath);
 		if(fs.exists(pathName)) {
-			   throw new IllegalArgumentException("File already exists");
-		}
+            throw new IllegalStateException("File already exists");
+        }
 		
 		FSDataOutputStream out= null;
 		try {
@@ -144,7 +142,7 @@ public class PigJobServerImpl implements PigJobServer {
 				try {
 					out.close();
 				} catch(Exception e) {
-				logger.error("Error while closing file ", e);
+			        logger.error("Error while closing file ", e);
 				}
 			}
 		}

--- a/service/src/main/java/org/pig/oink/rest/IOExceptionMapper.java
+++ b/service/src/main/java/org/pig/oink/rest/IOExceptionMapper.java
@@ -1,0 +1,80 @@
+/*
+Copyright 2013-2014 eBay Software Foundation
+ 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+ 
+    http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.pig.oink.rest;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.log4j.Logger;
+
+/**
+ * Handles uncaught IOExceptions. 
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ *
+ */
+@Provider
+public class IOExceptionMapper implements ExceptionMapper<IOException>{
+
+	/**
+	 * Log4j logger.
+	 */
+	private Logger logger= Logger.getLogger(IOExceptionMapper.class);
+
+	/**
+	 * HTTP request.
+	 */
+	@Context 
+	private HttpServletRequest request;
+	
+	/**
+	 * Maps an IOException to a Response with the body
+	 * containing the exception's message. The status code
+	 * is 404 NOT FOUND if the exception is FileNotFoundException or
+	 * 500 SERVER ERROR otherwise.
+	 */
+	@Override
+	public Response toResponse(IOException exception) {
+		
+		if (exception instanceof FileNotFoundException) {
+			logger.error(
+		        "FileNotFoundException when calling " +
+		        request.getRequestURL().toString() + 
+		        " ! Message: " + exception.getMessage()
+		    );
+	        return Response.status(HttpURLConnection.HTTP_NOT_FOUND).
+	            entity(exception.getMessage()).
+	            type(MediaType.TEXT_PLAIN).
+	            build();
+		}
+        logger.error(
+            "IOException when calling " +
+            request.getRequestURL().toString() + 
+            " ! Message: " + exception.getMessage()
+        );
+        return Response.serverError().
+	        entity(exception.getMessage()).
+            type(MediaType.TEXT_PLAIN).
+            build();
+	}
+}

--- a/service/src/main/java/org/pig/oink/rest/IllegalArgumentMapper.java
+++ b/service/src/main/java/org/pig/oink/rest/IllegalArgumentMapper.java
@@ -1,0 +1,66 @@
+/*
+Copyright 2013-2014 eBay Software Foundation
+ 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+ 
+    http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.pig.oink.rest;
+
+import java.net.HttpURLConnection;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.log4j.Logger;
+
+/**
+ * Handles uncaught IllegalArgumentExceptions. 
+ * Such exception is thrown for instance when a needed file is not found.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ *
+ */
+@Provider
+public class IllegalArgumentMapper implements ExceptionMapper<IllegalArgumentException>{
+
+	/**
+	 * Log4j logger.
+	 */
+	private Logger logger= Logger.getLogger(IllegalArgumentMapper.class);
+
+	/**
+	 * HTTP request.
+	 */
+	@Context 
+	private HttpServletRequest request;
+	
+	/**
+	 * Maps IllegalArgumentException to a Response with HTTP 404 status and
+	 * the body containing the exception's message.
+	 */
+	@Override
+	public Response toResponse(IllegalArgumentException exception) {
+        logger.error(
+            "IllegalArgumentException when calling " +
+            request.getRequestURL().toString() + 
+            " ! Message: " + exception.getMessage()
+        );
+        return Response.status(HttpURLConnection.HTTP_NOT_FOUND).
+            entity(exception.getMessage()).
+            type(MediaType.TEXT_PLAIN).
+            build();
+	}
+
+}

--- a/service/src/main/java/org/pig/oink/rest/IllegalStateMapper.java
+++ b/service/src/main/java/org/pig/oink/rest/IllegalStateMapper.java
@@ -1,0 +1,87 @@
+/*
+Copyright 2013-2014 eBay Software Foundation
+ 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+ 
+    http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.pig.oink.rest;
+
+import java.net.HttpURLConnection;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.log4j.Logger;
+
+/**
+ * Handles uncaught IllegalStateExceptions. 
+ * Such exception is thrown for instance when a needed file is not found.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ *
+ */
+@Provider
+public class IllegalStateMapper implements ExceptionMapper<IllegalStateException>{
+
+	/**
+	 * Log4j logger.
+	 */
+	private Logger logger= Logger.getLogger(IllegalStateMapper.class);
+
+	/**
+	 * HTTP request.
+	 */
+	@Context 
+	private HttpServletRequest request;
+
+    /**
+     * IllegalStateException might be thrown from PigResource.registerJar(...) or
+     * PigResource.registerScript(...) if the files that are being registered already
+     * exist on the server.
+     * @return Response with 409 CONFLICT HTTP status and a Json body containing steps
+     * to delete the registered file <b>OR</b><br> Response with 500 SERVER ERROR HTTP
+     * status if the IllegalStateException occurred for other reasons than the 2 mentioned above.
+     */
+    @Override
+    public Response toResponse(IllegalStateException exception) {
+        String url = request.getRequestURL().toString();
+    	logger.error(
+	        "IllegalStateException when calling " + url + 
+	        " ! Message: " + exception.getMessage()
+	    );
+        if(exception.getMessage().equals("File already exists")) { 
+            if(url.contains("/jar/") || url.contains("/script/")) {
+                return this.conflictResponse();
+    	    }
+        }
+		return Response.serverError()
+		    .entity(exception.getMessage())
+		    .type(MediaType.TEXT_PLAIN)
+		    .build();
+	}
+
+    public Response conflictResponse(){
+        String jsonBody = "{"
+            + "\"message\":\"File already exists. Try again after performing the fix.\",\n"
+        	+ "\"fix\":\"DELETE %s\"\n"
+        	+ "}";
+        return Response
+            .status(HttpURLConnection.HTTP_CONFLICT)
+            .entity(String.format(jsonBody, request.getRequestURL().toString()))
+            .type(MediaType.APPLICATION_JSON)
+            .build();
+    }
+}

--- a/service/src/main/java/org/pig/oink/rest/PigResource.java
+++ b/service/src/main/java/org/pig/oink/rest/PigResource.java
@@ -17,7 +17,6 @@ limitations under the License.
 package org.pig.oink.rest;
 
 import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
@@ -25,7 +24,6 @@ import java.net.HttpURLConnection;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.UUID;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -34,11 +32,9 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.pig.oink.bean.PigInputParameters;
@@ -50,7 +46,6 @@ import org.pig.oink.commons.PigScriptValidator;
 import org.pig.oink.operation.impl.PigJobServerImpl;
 import org.pig.oink.operation.impl.StreamingBinOutputImpl;
 import org.pig.oink.operation.impl.StreamingPigOutputImpl;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -63,43 +58,30 @@ public class PigResource {
 
 	@Context 
 	private HttpServletRequest requestInfo;
-
+	
 	@POST
 	@Path("/jar/{jarName}")
 	@Consumes ( {MediaType.APPLICATION_OCTET_STREAM} )
 	@Produces ({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN})
-	public Response registerJar(@PathParam("jarName") String jarName, InputStream uploadedJar) {
+	public Response registerJar(@PathParam("jarName") String jarName, InputStream uploadedJar) throws IOException {
 		logger.info("Request for registring jar with name " + jarName);
-		try {
-			if (uploadedJar == null || uploadedJar.available() == 0){
-				logger.error("Empty input stream passed");
-				return Response.status(400).entity("Bad request. No jar uploaded!").build();
-			}
-			String pathName= PropertyLoader.getInstance().getProperty(Constants.JARS_PATH) + jarName;
-			PigJobServerImpl.getPigJobServer().registerFile(pathName, uploadedJar);
-			return Response.ok().entity(pathName).type(MediaType.TEXT_PLAIN).build();
-		} catch (IOException ie) {
-			logger.error("Error while registering jar " + jarName, ie);
-			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
+	    if (uploadedJar == null || uploadedJar.available() == 0){
+		    logger.error("Empty input stream passed");
+			return Response.status(400).entity("Bad request. No jar uploaded!").build();
 		}
+		String pathName= PropertyLoader.getInstance().getProperty(Constants.JARS_PATH) + jarName;
+		PigJobServerImpl.getPigJobServer().registerFile(pathName, uploadedJar);
+		return Response.ok().entity(pathName).type(MediaType.TEXT_PLAIN).build();
 	}
 
 	@DELETE
 	@Path("/jar/{jarName}")
 	@Produces ( {MediaType.TEXT_PLAIN} )
-	public Response unregisterJar(@PathParam("jarName") String jarName) {
+	public Response unregisterJar(@PathParam("jarName") String jarName) throws IOException {
 		logger.info("Request for deleting jar " + jarName);
-		try {
-			String pathName= PropertyLoader.getInstance().getProperty(Constants.JARS_PATH) + jarName;
-			PigJobServerImpl.getPigJobServer().unregisterFile(pathName);
-			return Response.ok().entity("Delete Successful").build();
-		} catch (FileNotFoundException fnfe) {
-			logger.error("Error while deleting file " + jarName, fnfe);
-			throw new WebApplicationException(Response.status(404).entity(fnfe.getMessage()).build());
-		} catch (IOException ie) {
-			logger.error("Error while deleting file " + jarName, ie);
-			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		}
+		String pathName= PropertyLoader.getInstance().getProperty(Constants.JARS_PATH) + jarName;
+		PigJobServerImpl.getPigJobServer().unregisterFile(pathName);
+		return Response.ok().entity("Delete Successful").build();
 	}
 	
 	@GET
@@ -121,52 +103,41 @@ public class PigResource {
 	@Path("/script/{scriptName}")
 	@Consumes ( {MediaType.APPLICATION_OCTET_STREAM} )
 	@Produces ({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN})
-	public Response registerScript(@PathParam("scriptName") String scriptName, InputStream uploadedScript) {
+	public Response registerScript(@PathParam("scriptName") String scriptName, InputStream uploadedScript) throws IOException {
 		logger.info("Request for registering script " + scriptName);
-		try{
-			if (uploadedScript == null || uploadedScript.available() == 0){
-				logger.error("Empty input stream passed");
-				return Response.status(400).entity("Bad request. No script uploaded!").build();
-			}
-			   
-			StringWriter writer = new StringWriter();
-			try {
-				IOUtils.copy(uploadedScript, writer, "UTF-8");
-			} catch (IOException e) {
-				return Response.status(500).entity("Unable to read pig script").build();
-			}
-				
-			String script= writer.toString();
-			if (PigScriptValidator.validatePigScript(script)) {
-				InputStream stream= new ByteArrayInputStream(script.getBytes());
-				String pathName= PropertyLoader.getInstance().getProperty(Constants.SCRIPTS_PATH) + scriptName;
-				PigJobServerImpl.getPigJobServer().registerFile(pathName, stream);
-				return Response.ok().entity(pathName).build();
-			}
-			logger.info("Script " + scriptName + " is not valid");
-			return Response.status(400).entity("Bad Request. Either DUMP command is used or STORE is used without '$output'").build();
-		} catch (IOException ie) {
-			logger.error("Error while registering pig script " + scriptName , ie);
-			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
+		if (uploadedScript == null || uploadedScript.available() == 0){
+			logger.error("Empty input stream passed");
+			return Response
+			    .status(HttpURLConnection.HTTP_BAD_REQUEST)
+			    .entity("Bad request. No script uploaded!")
+			    .build();
 		}
+			   
+		StringWriter writer = new StringWriter();
+		IOUtils.copy(uploadedScript, writer, "UTF-8");
+				
+		String script= writer.toString();
+		if (PigScriptValidator.validatePigScript(script)) {
+			InputStream stream= new ByteArrayInputStream(script.getBytes());
+			String pathName= PropertyLoader.getInstance().getProperty(Constants.SCRIPTS_PATH) + scriptName;
+			PigJobServerImpl.getPigJobServer().registerFile(pathName, stream);
+			return Response.ok().entity(pathName).build();
+		}
+		logger.info("Script " + scriptName + " is not valid");
+		return Response
+		    .status(HttpURLConnection.HTTP_BAD_REQUEST)
+		    .entity("Bad Request. Either DUMP command is used or STORE is used without '$output'")
+		    .build();
 	}
 	   
 	@DELETE
 	@Path("/script/{scriptName}")
 	@Produces ( {MediaType.TEXT_PLAIN} )
-	public Response unregisterScript(@PathParam("scriptName") String scriptName) {
+	public Response unregisterScript(@PathParam("scriptName") String scriptName) throws IOException {
 		logger.info("Request for deleting script " + scriptName);
-		try {
-			String pathName= PropertyLoader.getInstance().getProperty(Constants.SCRIPTS_PATH) + scriptName;
-			PigJobServerImpl.getPigJobServer().unregisterFile(pathName);
-			return Response.ok().entity("Script deleted Successfully").build();
-		} catch (FileNotFoundException fnfe) {
-			logger.error("Error while deleteing script " + scriptName, fnfe);
-			throw new WebApplicationException(Response.status(404).entity(fnfe.getMessage()).build());
-		} catch (IOException ie) {
-			logger.error("Error while deleteing script " + scriptName, ie);
-			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		}
+		String pathName= PropertyLoader.getInstance().getProperty(Constants.SCRIPTS_PATH) + scriptName;
+		PigJobServerImpl.getPigJobServer().unregisterFile(pathName);
+		return Response.ok().entity("Script deleted Successfully").build();
 	}
 
 	@GET
@@ -179,7 +150,10 @@ public class PigResource {
 
 		if(streamingOutputImpl.isAvailable() == false) {
 			logger.info("Requested script " + scriptName + " not found.");
-			return Response.status(HttpURLConnection.HTTP_NOT_FOUND).entity("Script not found").build();				   
+			return Response
+			    .status(HttpURLConnection.HTTP_NOT_FOUND)
+			    .entity("Script not found")
+			    .build();				   
 		}
 		return Response.ok(streamingOutputImpl).build();
 	}
@@ -188,125 +162,90 @@ public class PigResource {
 	@Path("/request/{scriptName}")
 	@Consumes( {MediaType.APPLICATION_JSON} )
 	@Produces( {MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MediaType.TEXT_PLAIN} )
-	public Response submitPigJob(@PathParam("scriptName") String scriptName, String data){
+	public Response submitPigJob(@PathParam("scriptName") String scriptName, String data) throws IOException{
 		logger.info("Request for running script " + scriptName);
-		try {
-			Gson gson = new GsonBuilder().setPrettyPrinting().setDateFormat("yyyy/MM/dd-HH:mm").create();
-			PigInputParameters input = new PigInputParameters();
-			if(data != null) {
-				input= gson.fromJson(data, PigInputParameters.class);
-			}
-			PigRequestParameters request= new PigRequestParameters();
-			request.setHttpCallback(input.getHttpCallback());
-			request.setInputParameters(input.getInputParameters());
-			request.setPigScript(scriptName);
-			if (requestInfo != null){
-				request.setRequestIp(requestInfo.getRemoteAddr());
-			}
-			Date date= Calendar.getInstance().getTime();
-			request.setRequestStartTime(date);
-			String scriptId= UUID.randomUUID().toString();
-			logger.info("New request id generated " + scriptId + " for pig script " + scriptName);
-			PigJobServerImpl.getPigJobServer().submitPigJob(scriptId, scriptName, request);
-			return Response.ok().entity(scriptId).build();
-		} catch (IOException ie) {
-			logger.error("Error while getting request ", ie);
-			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
+		Gson gson = new GsonBuilder().setPrettyPrinting().setDateFormat("yyyy/MM/dd-HH:mm").create();
+		PigInputParameters input = new PigInputParameters();
+		if(data != null) {
+			input= gson.fromJson(data, PigInputParameters.class);
 		}
+		PigRequestParameters request= new PigRequestParameters();
+		request.setHttpCallback(input.getHttpCallback());
+		request.setInputParameters(input.getInputParameters());
+		request.setPigScript(scriptName);
+		if (requestInfo != null){
+			request.setRequestIp(requestInfo.getRemoteAddr());
+		}
+		Date date= Calendar.getInstance().getTime();
+		request.setRequestStartTime(date);
+		String scriptId= UUID.randomUUID().toString();
+		logger.info("New request id generated " + scriptId + " for pig script " + scriptName);
+		PigJobServerImpl.getPigJobServer().submitPigJob(scriptId, scriptName, request);
+		return Response.ok().entity(scriptId).build();
 	}
 	   
 	@GET 
 	@Path("/request/{requestId}")
 	@Produces( {MediaType.APPLICATION_JSON} )
-	public Response getInput(@PathParam("requestId") String requestId) {
+	public Response getInput(@PathParam("requestId") String requestId) throws IOException {
 		logger.info("Request for getting request " + requestId);
-		PigRequestParameters params= null;
-		try {
-			params = PigJobServerImpl.getPigJobServer().getInputRequest(requestId);
-			Gson gson= new Gson();
-			return Response.ok().entity(gson.toJson(params, PigRequestParameters.class)).build();	
-		} catch (FileNotFoundException fnfe) {
-			logger.error("Error while getting request " + requestId, fnfe);
-			throw new WebApplicationException(Response.status(404).entity(fnfe.getMessage()).build());
-		}catch (IOException ie) {
-			logger.error("Error while getting request " + requestId, ie);
-			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		}
+		PigRequestParameters params = PigJobServerImpl
+		    .getPigJobServer()
+		    .getInputRequest(requestId);
+		return Response.ok()
+		    .entity(new Gson().toJson(params, PigRequestParameters.class))
+		    .build();	
 	}
 
 	@GET 
 	@Path("/request/{requestId}/stats")
 	@Produces( {MediaType.APPLICATION_JSON} )
-	public Response getRequestStats(@PathParam("requestId") String requestId) {
+	public Response getRequestStats(@PathParam("requestId") String requestId) throws IOException {
 		logger.info("Request for getting stats for request " + requestId);
-		PigRequestStats stats= null;
-		try {
-			stats = PigJobServerImpl.getPigJobServer().getRequestStats(requestId);
-			Gson gson= new Gson();
-			return Response.ok().entity(gson.toJson(stats, PigRequestStats.class)).build();
-		} catch (FileNotFoundException fnfe) {
-			logger.error("Error while getting stats for request " + requestId, fnfe);
-			throw new WebApplicationException(Response.status(404).entity(fnfe.getMessage()).build());
-		} catch (IOException ie) {
-			logger.error("Error while getting stats for request " + requestId, ie);
-			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		}
+		PigRequestStats stats = PigJobServerImpl
+		    .getPigJobServer()
+		    .getRequestStats(requestId);
+		return Response.ok()
+		    .entity(new Gson().toJson(stats, PigRequestStats.class))
+		    .build();
 	}
 	   
 	@GET 
 	@Path("/request/{requestId}/output")
 	@Produces( {MediaType.TEXT_PLAIN} )
-	public Response getOutput(@PathParam("requestId") String requestId) {
-		try {
-		    logger.info("Request for reading output for " + requestId);
-		    String outputPath= PropertyLoader.getInstance().getProperty(Constants.REQUEST_PATH) + requestId;
-		    StreamingPigOutputImpl streamingPigOutputImpl = new StreamingPigOutputImpl(outputPath);	
+	public Response getOutput(@PathParam("requestId") String requestId) throws IOException {
+        logger.info("Request for reading output for " + requestId);
+		String outputPath= PropertyLoader.getInstance().getProperty(Constants.REQUEST_PATH) + requestId;
+		StreamingPigOutputImpl streamingPigOutputImpl = new StreamingPigOutputImpl(outputPath);	
    
-		    if(streamingPigOutputImpl.isAvailable() == false) {
-			    logger.info("Request " + requestId + " not available");
-			    return Response.status(404).entity("Invalid Request ID").build();				   
-	        }
-		    return Response.ok(streamingPigOutputImpl).build();
-		} catch (IOException ie) {
-			logger.error("Error while getting stats for request " + requestId, ie);
-			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		}
+		if(streamingPigOutputImpl.isAvailable() == false) {
+		    logger.info("Request " + requestId + " not available");
+			return Response.status(404).entity("Invalid Request ID").build();				   
+	    }
+		return Response.ok(streamingPigOutputImpl).build();
 	}
 	   
 	   
 	@GET
 	@Path("request/{requestId}/status")
 	@Produces( {MediaType.TEXT_PLAIN} )
-	public Response getRequestStatus(@PathParam("requestId") String requestId) {
+	public Response getRequestStatus(@PathParam("requestId") String requestId) throws IOException {
 		logger.info("Request for retrieving status for " + requestId);
-		String status= null;
-		try {
-			status = PigJobServerImpl.getPigJobServer().getRequestStatus(requestId);
-			return Response.ok().entity(status).build();
-		} catch (IOException ie) {
-			logger.error("Error while getting status for " + requestId, ie);
-			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		}
+		return Response.ok()
+		    .entity(
+		        PigJobServerImpl.getPigJobServer().getRequestStatus(requestId)
+		    ).build();
 	}
 	   
 	@GET
 	@Path("request/{requestId}/cancel")
 	@Produces( {MediaType.TEXT_PLAIN} )
-	public Response cancelRequest(@PathParam("requestId") String requestId) {
+	public Response cancelRequest(@PathParam("requestId") String requestId) throws IOException {
 		logger.info("Request for cancelling request " + requestId);
-		boolean status= false;
-		try {
-			status = PigJobServerImpl.getPigJobServer().cancelRequest(requestId);
-			
-			if (status) {
-				return Response.ok().entity("Jobs cancelled").build();
-			} else {
-				return Response.status(500).entity("Request doesnt have any running jobs").build();
-			}
-				
-		} catch (IOException ie) {
-			logger.error("Error while cancelling request " + requestId, ie);
-			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
+		boolean status = PigJobServerImpl.getPigJobServer().cancelRequest(requestId);	
+		if (status) {
+		    return Response.ok().entity("Jobs cancelled").build();
 		}
+		return Response.serverError().entity("Request doesnt have any running jobs").build();		
 	}
 }

--- a/service/src/main/java/org/pig/oink/rest/PigResource.java
+++ b/service/src/main/java/org/pig/oink/rest/PigResource.java
@@ -68,7 +68,7 @@ public class PigResource {
 	@Path("/jar/{jarName}")
 	@Consumes ( {MediaType.APPLICATION_OCTET_STREAM} )
 	@Produces ({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN})
-	public Response registerJar(@PathParam("jarName") String jarName, InputStream uploadedJar) throws IOException {
+	public Response registerJar(@PathParam("jarName") String jarName, InputStream uploadedJar) {
 		logger.info("Request for registring jar with name " + jarName);
 		try {
 			if (uploadedJar == null || uploadedJar.available() == 0){
@@ -81,9 +81,6 @@ public class PigResource {
 		} catch (IOException ie) {
 			logger.error("Error while registering jar " + jarName, ie);
 			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		} catch (Exception e) {
-			logger.error("Error while registering jar " + jarName, e);
-			throw new WebApplicationException(Response.status(500).entity(e.getMessage()).build());
 		}
 	}
 
@@ -102,9 +99,6 @@ public class PigResource {
 		} catch (IOException ie) {
 			logger.error("Error while deleting file " + jarName, ie);
 			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		} catch (Exception e) {
-			logger.error("Error while deleting file " + jarName, e);
-			throw new WebApplicationException(Response.status(500).entity(e.getMessage()).build());
 		}
 	}
 	
@@ -113,27 +107,21 @@ public class PigResource {
 	@Produces ( {MediaType.APPLICATION_OCTET_STREAM} )
 	public Response getRegisteredJar(@PathParam("jarName") String jarName) {
 		logger.info("REquest for getting jar " + jarName);
-		try {
-			String jarPath= PropertyLoader.getInstance().getProperty(Constants.JARS_PATH) + jarName;
-			StreamingBinOutputImpl streamingOutputImpl = new StreamingBinOutputImpl(jarPath);	
-			   
-			if(streamingOutputImpl.isAvailable() == false) {
-				logger.info("Requested jar " + jarName + " is not found");
-				return Response.status(HttpURLConnection.HTTP_NOT_FOUND).entity("Jar not found").build();				   
-			} else {
-				return Response.ok(streamingOutputImpl).build();
-			}
-		} catch (Exception ie){
-			logger.error("Error while getting jar "+ jarName, ie);
-			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
+		String jarPath= PropertyLoader.getInstance().getProperty(Constants.JARS_PATH) + jarName;
+		StreamingBinOutputImpl streamingOutputImpl = new StreamingBinOutputImpl(jarPath);	
+	   
+		if(streamingOutputImpl.isAvailable() == false) {
+		    logger.info("Requested jar " + jarName + " is not found");
+			return Response.status(HttpURLConnection.HTTP_NOT_FOUND).entity("Jar not found").build();				   
 		}
+		return Response.ok(streamingOutputImpl).build();
 	}
 	
 	@POST
 	@Path("/script/{scriptName}")
 	@Consumes ( {MediaType.APPLICATION_OCTET_STREAM} )
 	@Produces ({MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN})
-	public Response registerScript(@PathParam("scriptName") String scriptName, InputStream uploadedScript) throws IOException {
+	public Response registerScript(@PathParam("scriptName") String scriptName, InputStream uploadedScript) {
 		logger.info("Request for registering script " + scriptName);
 		try{
 			if (uploadedScript == null || uploadedScript.available() == 0){
@@ -160,9 +148,6 @@ public class PigResource {
 		} catch (IOException ie) {
 			logger.error("Error while registering pig script " + scriptName , ie);
 			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		} catch (Exception e) {
-			logger.error("Error while registering pig script " + scriptName , e);
-			throw new WebApplicationException(Response.status(500).entity(e.getMessage()).build());
 		}
 	}
 	   
@@ -181,31 +166,22 @@ public class PigResource {
 		} catch (IOException ie) {
 			logger.error("Error while deleteing script " + scriptName, ie);
 			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		} catch (Exception e) {
-			logger.error("Error while deleteing script " + scriptName, e);
-			throw new WebApplicationException(Response.status(500).entity(e.getMessage()).build());
 		}
 	}
-	   
+
 	@GET
 	@Path("/script/{scriptName}")
 	@Produces ( {MediaType.APPLICATION_OCTET_STREAM} )
 	public Response getRegisteredScript(@PathParam("scriptName") String scriptName) {
 		logger.info("Request for getting script " + scriptName);
-		try {
-			String scriptPath= PropertyLoader.getInstance().getProperty(Constants.SCRIPTS_PATH) + scriptName;
-			StreamingBinOutputImpl streamingOutputImpl = new StreamingBinOutputImpl(scriptPath);	
-			
-			if(streamingOutputImpl.isAvailable() == false) {
-				logger.info("Requested script " + scriptName + " not found.");
-				return Response.status(HttpURLConnection.HTTP_NOT_FOUND).entity("Script not found").build();				   
-			} else {
-				return Response.ok(streamingOutputImpl).build();
-			}
-		} catch (Exception ie) {
-			logger.error("Error while retrieving pig script " + scriptName, ie);
-			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
+		String scriptPath= PropertyLoader.getInstance().getProperty(Constants.SCRIPTS_PATH) + scriptName;
+		StreamingBinOutputImpl streamingOutputImpl = new StreamingBinOutputImpl(scriptPath);	
+
+		if(streamingOutputImpl.isAvailable() == false) {
+			logger.info("Requested script " + scriptName + " not found.");
+			return Response.status(HttpURLConnection.HTTP_NOT_FOUND).entity("Script not found").build();				   
 		}
+		return Response.ok(streamingOutputImpl).build();
 	}
 
 	@POST
@@ -234,7 +210,7 @@ public class PigResource {
 			PigJobServerImpl.getPigJobServer().submitPigJob(scriptId, scriptName, request);
 			return Response.ok().entity(scriptId).build();
 		} catch (IOException ie) {
-			logger.error("Error while submitting script " + scriptName, ie);
+			logger.error("Error while getting request ", ie);
 			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
 		}
 	}
@@ -255,9 +231,6 @@ public class PigResource {
 		}catch (IOException ie) {
 			logger.error("Error while getting request " + requestId, ie);
 			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		}catch (Exception e) {
-			logger.error("Error while getting request " + requestId, e);
-			throw new WebApplicationException(Response.status(500).entity(e.getMessage()).build());
 		}
 	}
 
@@ -277,9 +250,6 @@ public class PigResource {
 		} catch (IOException ie) {
 			logger.error("Error while getting stats for request " + requestId, ie);
 			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		} catch (Exception e) {
-			logger.error("Error while getting stats for request " + requestId, e);
-			throw new WebApplicationException(Response.status(500).entity(e.getMessage()).build());
 		}
 	}
 	   
@@ -287,19 +257,18 @@ public class PigResource {
 	@Path("/request/{requestId}/output")
 	@Produces( {MediaType.TEXT_PLAIN} )
 	public Response getOutput(@PathParam("requestId") String requestId) {
-		logger.info("Request for reading output for " + requestId);
 		try {
-			String outputPath= PropertyLoader.getInstance().getProperty(Constants.REQUEST_PATH) + requestId;
-			StreamingPigOutputImpl streamingPigOutputImpl = new StreamingPigOutputImpl(outputPath);	
-			   
-			if(streamingPigOutputImpl.isAvailable() == false) {
-				logger.info("Request " + requestId + " not available");
-				return Response.status(404).entity("Invalid Request ID").build();				   
-			} else {
-				return Response.ok(streamingPigOutputImpl).build();
-			}
+		    logger.info("Request for reading output for " + requestId);
+		    String outputPath= PropertyLoader.getInstance().getProperty(Constants.REQUEST_PATH) + requestId;
+		    StreamingPigOutputImpl streamingPigOutputImpl = new StreamingPigOutputImpl(outputPath);	
+   
+		    if(streamingPigOutputImpl.isAvailable() == false) {
+			    logger.info("Request " + requestId + " not available");
+			    return Response.status(404).entity("Invalid Request ID").build();				   
+	        }
+		    return Response.ok(streamingPigOutputImpl).build();
 		} catch (IOException ie) {
-			logger.error("Error while reading output for " + requestId, ie);
+			logger.error("Error while getting stats for request " + requestId, ie);
 			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
 		}
 	}
@@ -317,9 +286,6 @@ public class PigResource {
 		} catch (IOException ie) {
 			logger.error("Error while getting status for " + requestId, ie);
 			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		} catch (Exception e) {
-			logger.error("Error while getting status for " + requestId, e);
-			throw new WebApplicationException(Response.status(500).entity(e.getMessage()).build());
 		}
 	}
 	   
@@ -341,9 +307,6 @@ public class PigResource {
 		} catch (IOException ie) {
 			logger.error("Error while cancelling request " + requestId, ie);
 			throw new WebApplicationException(Response.status(500).entity(ie.getMessage()).build());
-		} catch (Exception e) {
-			logger.error("Error while cancelling request " + requestId, e);
-			throw new WebApplicationException(Response.status(500).entity(e.getMessage()).build());
 		}
 	}
 }


### PR DESCRIPTION
PR for issue #3 

Wrote exception handlers to clean all the ``try{ }catch`` code from [this](https://github.com/eBay/oink/blob/master/service/src/main/java/org/pig/oink/rest/PigResource.java) class.

Also refactored exception handling from [this](https://github.com/eBay/oink/blob/master/service/src/main/java/org/pig/oink/operation/impl/PigJobServerImpl.java) class... more precicely, now ``IOException`` is thrown instead of a bare ``Exception``, method declarations are simplified and removed unnecessary runtime exception declarations.

**Changes that might affect existing clients:**
- In case of 409 a json object is returned instead of plain text with the exception message. 

Initially I thought 409 is not an appropriate status to be returned, but since we have delete methods for the registered files, then it's fine.. because as explained [here](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html), 409 should be returned when there is a conflict (it's true, there is a conflict in our case, the files already exist on the server) **and also**, the server should return appropriate information in order for the client to fix the problem and retry the operation. This is why the json object is returned: it contains a message and a fix attribute, so the client knows what to do. The json looks like this in case of the registerScript method
```
{
    "message":"File already exists. Try again after performing the fix.",
    "fix":"DELETE domain/oink/script/{scriptName}"
}
```
- Method ``public Response submitPigJob(...)`` returned HTTP 400 on IllegalArgumentException. Now it returns HTTP 404, the same as others. I figured it was a mistake since the javadoc of ``PigJobServerImpl.submitPigJob(...)`` (this is the method that might throw IAE) says 404 should be thrown.

I tested on both Tomcat 6 and the latest Tomcat and the exception mappers worked fine. Also I ran both ``mvn clean test`` and ``mvn clean install`` and both are successfull.